### PR TITLE
redesign: bright Customer Cloud-style dashboard UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.6",
+    "playwright": "^1.60.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 12.40.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -69,6 +69,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -87,6 +90,9 @@ importers:
       eslint-config-next:
         specifier: 16.2.6
         version: 16.2.6(@typescript-eslint/parser@8.60.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      playwright:
+        specifier: ^1.60.0
+        version: 1.60.0
       tailwindcss:
         specifier: ^4
         version: 4.3.0
@@ -683,6 +689,11 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
@@ -1775,6 +1786,11 @@ packages:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -2629,6 +2645,16 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3819,6 +3845,10 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
 
   '@rtsao/scc@1.1.0': {}
 
@@ -5050,6 +5080,9 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -5626,7 +5659,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.6(@babel/core@7.29.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@babel/core@7.29.7)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -5645,6 +5678,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5822,6 +5856,14 @@ snapshots:
   picomatch@4.0.4: {}
 
   pkce-challenge@5.0.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,20 +9,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
-  --color-sidebar-ring: var(--sidebar-ring);
-  --color-sidebar-border: var(--sidebar-border);
-  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
-  --color-sidebar-accent: var(--sidebar-accent);
-  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
-  --color-sidebar-primary: var(--sidebar-primary);
-  --color-sidebar-foreground: var(--sidebar-foreground);
-  --color-sidebar: var(--sidebar);
-  --color-chart-5: var(--chart-5);
-  --color-chart-4: var(--chart-4);
-  --color-chart-3: var(--chart-3);
-  --color-chart-2: var(--chart-2);
-  --color-chart-1: var(--chart-1);
+  --font-heading: var(--font-heading);
   --color-ring: var(--ring);
   --color-input: var(--input);
   --color-border: var(--border);
@@ -39,91 +26,79 @@
   --color-popover: var(--popover);
   --color-card-foreground: var(--card-foreground);
   --color-card: var(--card);
-  --color-brand: var(--brand);
-  --color-brand-foreground: var(--brand-foreground);
-  --color-brand-soft: var(--brand-soft);
+  /* AutoCM brand palette (vibrant) */
+  --color-brand-blue: var(--brand-blue);
+  --color-brand-purple: var(--brand-purple);
+  --color-brand-pink: var(--brand-pink);
+  --color-cta: var(--cta);
+  --color-cta-end: var(--cta-end);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-muted: var(--sidebar-muted);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) * 1.4);
   --radius-2xl: calc(var(--radius) * 1.8);
-  --radius-3xl: calc(var(--radius) * 2.2);
-  --radius-4xl: calc(var(--radius) * 2.6);
+  --radius-3xl: calc(var(--radius) * 2.4);
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --radius: 0.875rem;
+
+  --background: oklch(0.985 0.006 255);
+  --foreground: oklch(0.25 0.04 265);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.25 0.04 265);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --brand: oklch(0.77 0.16 64);
-  --brand-foreground: oklch(0.22 0.03 60);
-  --brand-soft: oklch(0.95 0.04 75);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.77 0.16 64);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --popover-foreground: oklch(0.25 0.04 265);
+
+  --primary: oklch(0.58 0.22 292);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.96 0.02 280);
+  --secondary-foreground: oklch(0.32 0.05 280);
+  --muted: oklch(0.96 0.01 270);
+  --muted-foreground: oklch(0.55 0.03 275);
+  --accent: oklch(0.95 0.04 300);
+  --accent-foreground: oklch(0.32 0.08 295);
+  --destructive: oklch(0.62 0.23 18);
+
+  --border: oklch(0.92 0.01 280);
+  --input: oklch(0.92 0.01 280);
+  --ring: oklch(0.58 0.22 292);
+
+  /* Vibrant brand */
+  --brand-blue: oklch(0.62 0.2 258);
+  --brand-purple: oklch(0.58 0.24 296);
+  --brand-pink: oklch(0.66 0.23 0);
+  --cta: oklch(0.82 0.16 78);
+  --cta-end: oklch(0.72 0.2 47);
+
+  /* Dark navy sidebar */
+  --sidebar: oklch(0.24 0.06 277);
+  --sidebar-foreground: oklch(0.96 0.01 270);
+  --sidebar-muted: oklch(0.7 0.04 277);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --brand: oklch(0.8 0.16 68);
-  --brand-foreground: oklch(0.18 0.02 60);
-  --brand-soft: oklch(0.32 0.06 65);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.8 0.16 68);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.18 0.03 270);
+  --foreground: oklch(0.96 0.01 270);
+  --card: oklch(0.24 0.04 272);
+  --card-foreground: oklch(0.96 0.01 270);
+  --popover: oklch(0.24 0.04 272);
+  --popover-foreground: oklch(0.96 0.01 270);
+  --primary: oklch(0.7 0.2 295);
+  --primary-foreground: oklch(0.18 0.03 270);
+  --secondary: oklch(0.3 0.04 275);
+  --secondary-foreground: oklch(0.96 0.01 270);
+  --muted: oklch(0.3 0.03 275);
+  --muted-foreground: oklch(0.72 0.03 275);
+  --accent: oklch(0.34 0.06 295);
+  --accent-foreground: oklch(0.96 0.01 270);
+  --destructive: oklch(0.7 0.19 20);
+  --border: oklch(1 0 0 / 12%);
+  --input: oklch(1 0 0 / 16%);
+  --ring: oklch(0.7 0.2 295);
 }
 
 @layer base {
@@ -132,30 +107,43 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-feature-settings: "ss01", "cv01";
   }
   html {
     @apply font-sans;
   }
   h1, h2, h3, h4 {
     font-family: var(--font-heading);
-    letter-spacing: -0.02em;
   }
 }
 
 @layer utilities {
-  /* Cinematic warm gradient — deliberately NOT purple-on-white (brand rule). */
-  .bg-gradient-brand {
-    background-image: linear-gradient(135deg, var(--brand) 0%, oklch(0.62 0.2 28) 100%);
+  .bg-gradient-primary {
+    background-image: linear-gradient(120deg, var(--brand-blue) 0%, var(--brand-purple) 55%, var(--brand-pink) 100%);
   }
-  .text-gradient-brand {
-    background-image: linear-gradient(120deg, var(--brand) 0%, oklch(0.72 0.18 36) 100%);
+  .text-gradient-primary {
+    background-image: linear-gradient(100deg, var(--brand-blue) 0%, var(--brand-purple) 50%, var(--brand-pink) 100%);
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
   }
-  .grain {
-    background-image: radial-gradient(oklch(1 0 0 / 4%) 1px, transparent 1px);
-    background-size: 4px 4px;
+  .bg-gradient-cta {
+    background-image: linear-gradient(180deg, var(--cta) 0%, var(--cta-end) 100%);
+  }
+  .bg-gradient-hero {
+    background-image:
+      radial-gradient(120% 80% at 80% 0%, oklch(0.9 0.08 250 / 70%) 0%, transparent 55%),
+      linear-gradient(180deg, oklch(0.72 0.13 245) 0%, oklch(0.82 0.1 240) 45%, oklch(0.93 0.05 250) 100%);
+  }
+  .bg-sidebar-grad {
+    background-image: linear-gradient(190deg, oklch(0.26 0.07 280) 0%, oklch(0.2 0.06 285) 100%);
+  }
+  .glow {
+    box-shadow: 0 10px 30px -8px oklch(0.58 0.22 292 / 35%);
+  }
+  .glow-cta {
+    box-shadow: 0 10px 26px -6px oklch(0.75 0.18 60 / 50%);
+  }
+  .card-soft {
+    box-shadow: 0 1px 2px oklch(0.5 0.05 280 / 6%), 0 8px 24px -12px oklch(0.5 0.05 280 / 18%);
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,18 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Sora } from "next/font/google";
+import { M_PLUS_Rounded_1c, Geist_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
-const geistSans = Geist({
+const rounded = M_PLUS_Rounded_1c({
   variable: "--font-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "700", "800"],
+});
+
+const roundedHeading = M_PLUS_Rounded_1c({
+  variable: "--font-heading",
+  subsets: ["latin"],
+  weight: ["700", "800"],
 });
 
 const geistMono = Geist_Mono({
@@ -13,19 +20,13 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-const sora = Sora({
-  variable: "--font-heading",
-  subsets: ["latin"],
-  weight: ["500", "600", "700"],
-});
-
 export const metadata: Metadata = {
-  title: "AutoCM Studio — AI広告動画ジェネレーター",
+  title: "auto-cm — AIと一緒に、ワクワクするCMを作ろう！",
   description:
     "商品画像をアップロードするだけで、プロ品質のCM動画をAIが自動生成。Sora 2・Veo 3・Kling・Seedance・HeyGen を選んで比較。",
-  metadataBase: new URL("https://auto-cm.vercel.app"),
+  metadataBase: new URL("https://auto-cm-flame.vercel.app"),
   openGraph: {
-    title: "AutoCM Studio",
+    title: "auto-cm",
     description: "画像1枚から、プロ品質のCM動画を。",
     type: "website",
   },
@@ -39,10 +40,10 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`dark ${geistSans.variable} ${geistMono.variable} ${sora.variable} h-full antialiased`}
+      className={`${rounded.variable} ${roundedHeading.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col bg-background text-foreground">
+      <body className="min-h-full bg-background text-foreground">
         {children}
         <Toaster position="top-center" richColors />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,9 @@
-import { Clapperboard, ExternalLink, Sparkles } from "lucide-react";
-import { Studio } from "@/components/studio/studio";
+import { Sidebar } from "@/components/dashboard/sidebar";
+import { Topbar } from "@/components/dashboard/topbar";
+import { StudioLauncher } from "@/components/dashboard/studio-launcher";
+import { RecentProjects } from "@/components/dashboard/recent-projects";
+import { GenerationResults } from "@/components/dashboard/generation-results";
+import { StatCards } from "@/components/dashboard/stat-cards";
 import { ALL_ENGINE_IDS, isEngineLive, mockMode } from "@/lib/engines";
 import type { EngineId } from "@/lib/engines/types";
 
@@ -8,60 +12,25 @@ export default function Home() {
   const demo = mockMode() || liveEngines.length === 0;
 
   return (
-    <main className="relative flex-1">
-      {/* Header */}
-      <header className="sticky top-0 z-40 border-b border-border/60 bg-background/70 backdrop-blur">
-        <div className="mx-auto flex max-w-5xl items-center justify-between px-4 py-3">
-          <div className="flex items-center gap-2">
-            <span className="flex size-8 items-center justify-center rounded-lg bg-gradient-brand text-brand-foreground">
-              <Clapperboard className="size-4" />
-            </span>
-            <span className="font-heading text-lg font-bold">AutoCM Studio</span>
+    <div className="flex min-h-dvh bg-background">
+      <Sidebar />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Topbar />
+        <main className="mx-auto w-full max-w-6xl flex-1 space-y-5 px-4 py-5 sm:px-6">
+          <StudioLauncher liveEngines={liveEngines} demo={demo} />
+
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,360px)_1fr]">
+            <RecentProjects />
+            <GenerationResults />
           </div>
-          <a
-            href="https://github.com/ryoma3736/auto-cm"
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            aria-label="GitHub リポジトリ"
-          >
-            GitHub <ExternalLink className="size-4" />
-          </a>
-        </div>
-      </header>
 
-      {/* Hero */}
-      <section className="relative overflow-hidden">
-        <div className="pointer-events-none absolute inset-0 grain opacity-60" aria-hidden />
-        <div className="mx-auto max-w-5xl px-4 pb-10 pt-16 text-center sm:pt-20">
-          <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3 py-1 text-xs text-muted-foreground">
-            <Sparkles className="size-3.5 text-brand" />
-            5つの生成エンジンを切り替え・比較
-          </span>
-          <h1 className="mx-auto mt-5 max-w-3xl text-balance font-heading text-4xl font-bold leading-tight sm:text-6xl">
-            商品画像1枚から、
-            <span className="text-gradient-brand">プロ品質のCM動画</span>を。
-          </h1>
-          <p className="mx-auto mt-4 max-w-xl text-pretty text-muted-foreground sm:text-lg">
-            アップロード → AIが商品を解析し台本を生成 → エンジンを選んで生成。
-            Sora 2・Veo 3・Kling・Seedance・HeyGen に対応。
-          </p>
-          {demo && (
-            <p className="mt-4 text-xs text-muted-foreground">
-              現在<strong className="text-brand">デモモード</strong>で動作中（APIキー未設定）。サンプル動画で全フローを体験できます。
-            </p>
-          )}
-        </div>
-      </section>
+          <StatCards />
 
-      {/* Studio */}
-      <section className="mx-auto max-w-5xl px-4 pb-24">
-        <Studio liveEngines={liveEngines} />
-      </section>
-
-      <footer className="border-t border-border/60 py-6 text-center text-xs text-muted-foreground">
-        AutoCM Studio · Powered by Next.js + Vercel
-      </footer>
-    </main>
+          <footer className="pt-2 text-center text-xs text-muted-foreground">
+            auto-cm · Powered by Next.js + Vercel
+          </footer>
+        </main>
+      </div>
+    </div>
   );
 }

--- a/src/components/dashboard/engine-accent.ts
+++ b/src/components/dashboard/engine-accent.ts
@@ -1,0 +1,28 @@
+import type { EngineId } from "@/lib/engines/types";
+
+/** Per-engine accent gradients matched to the reference design. */
+export const ENGINE_ACCENT: Record<EngineId, string> = {
+  sora2: "from-blue-400 to-blue-600",
+  veo3: "from-teal-400 to-emerald-600",
+  kling: "from-orange-400 to-amber-600",
+  seedance: "from-violet-400 to-purple-600",
+  heygen: "from-pink-400 to-rose-600",
+};
+
+/** Softer thumbnail backgrounds per engine. */
+export const ENGINE_THUMB: Record<EngineId, string> = {
+  sora2: "from-amber-200 via-orange-200 to-rose-200",
+  veo3: "from-indigo-300 via-blue-300 to-sky-200",
+  kling: "from-orange-300 via-amber-200 to-yellow-200",
+  seedance: "from-fuchsia-300 via-purple-300 to-indigo-300",
+  heygen: "from-rose-200 via-pink-200 to-orange-200",
+};
+
+/** Short label shown on pills/cards (e.g. "Sora2", "Veo3"). */
+export const ENGINE_SHORT: Record<EngineId, string> = {
+  sora2: "Sora2",
+  veo3: "Veo3",
+  kling: "Kling",
+  seedance: "Seedance",
+  heygen: "HeyGen",
+};

--- a/src/components/dashboard/engine-pills.tsx
+++ b/src/components/dashboard/engine-pills.tsx
@@ -1,0 +1,20 @@
+import { ALL_ENGINE_IDS } from "@/lib/engines/catalog";
+import { ENGINE_ACCENT, ENGINE_SHORT } from "./engine-accent";
+
+/** Dark translucent engine bar that overlays the hero bottom (matches reference). */
+export function EnginePills() {
+  return (
+    <div className="mx-auto flex max-w-3xl flex-wrap items-center justify-center gap-x-5 gap-y-2 rounded-2xl border border-white/15 bg-black/25 px-5 py-3 backdrop-blur">
+      {ALL_ENGINE_IDS.map((id) => (
+        <div key={id} className="inline-flex items-center gap-2 text-sm font-bold text-white">
+          <span
+            className={`grid size-7 place-items-center rounded-full bg-gradient-to-br ${ENGINE_ACCENT[id]} text-xs text-white shadow`}
+          >
+            {ENGINE_SHORT[id].charAt(0)}
+          </span>
+          {ENGINE_SHORT[id]}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/dashboard/generation-results.tsx
+++ b/src/components/dashboard/generation-results.tsx
@@ -1,0 +1,34 @@
+import { CheckCircle2, Play } from "lucide-react";
+import { ALL_ENGINE_IDS } from "@/lib/engines/catalog";
+import { ENGINE_ACCENT, ENGINE_THUMB, ENGINE_SHORT } from "./engine-accent";
+
+export function GenerationResults() {
+  return (
+    <div className="rounded-2xl border border-border bg-card p-4 card-soft">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="font-heading text-base font-bold">生成結果（5エンジン同時完了）</h2>
+        <button className="text-xs font-semibold text-brand-purple hover:underline">すべて見る →</button>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {ALL_ENGINE_IDS.map((id) => (
+          <div key={id} className="overflow-hidden rounded-xl border border-border">
+            <div className={`bg-gradient-to-r ${ENGINE_ACCENT[id]} px-2.5 py-1.5`}>
+              <span className="text-xs font-bold text-white">{ENGINE_SHORT[id]}</span>
+            </div>
+            <div className={`relative grid aspect-[3/4] place-items-center bg-gradient-to-br ${ENGINE_THUMB[id]}`}>
+              <span className="grid size-10 place-items-center rounded-full bg-white/85 text-foreground shadow">
+                <Play className="size-4 translate-x-px fill-current" />
+              </span>
+              <span className="absolute bottom-1.5 left-1.5 rounded bg-black/55 px-1.5 py-0.5 text-[10px] font-medium text-white tabular-nums">
+                00:30
+              </span>
+            </div>
+            <div className="flex items-center gap-1 px-2 py-1.5 text-xs font-semibold text-emerald-600">
+              <CheckCircle2 className="size-3.5" /> Succeed
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/hero.tsx
+++ b/src/components/dashboard/hero.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { ArrowRight, Rocket, Sparkles } from "lucide-react";
+import { motion } from "motion/react";
+import { Mascot } from "./mascot";
+import { EnginePills } from "./engine-pills";
+
+const STEPS = [
+  { n: 1, title: "商品を入力", sub: "URL・画像をアップロード", emoji: "📦", hue: 255, ring: "from-blue-400 to-blue-600" },
+  { n: 2, title: "AIが企画", sub: "台本・構成を自動生成", emoji: "🎬", hue: 320, ring: "from-fuchsia-400 to-purple-600" },
+  { n: 3, title: "CMを生成", sub: "5エンジンで同時生成", emoji: "✨", hue: 150, ring: "from-emerald-400 to-teal-600" },
+];
+
+export function Hero({ onStart }: { onStart: () => void }) {
+  return (
+    <section className="bg-gradient-hero relative overflow-hidden rounded-3xl px-4 py-7 sm:px-8 sm:py-9">
+      {/* ===== Decorative film-set scene (CSS/emoji approximation) ===== */}
+      <div className="pointer-events-none absolute inset-0 select-none">
+        {/* clouds */}
+        <div className="absolute left-[6%] top-8 h-10 w-28 rounded-full bg-white/70 blur-md" />
+        <div className="absolute left-[26%] top-4 h-8 w-20 rounded-full bg-white/60 blur-md" />
+        <div className="absolute right-[30%] top-10 h-9 w-24 rounded-full bg-white/55 blur-md" />
+        {/* studio light + camera + chair (left) */}
+        <span className="absolute left-3 top-6 text-4xl drop-shadow sm:text-5xl">🎥</span>
+        <span className="absolute bottom-6 left-5 text-3xl drop-shadow sm:text-4xl">🎬</span>
+        {/* rainbow + balloon (right) */}
+        <span className="absolute right-6 top-4 text-4xl drop-shadow sm:text-5xl">🌈</span>
+        <span className="absolute right-[16%] top-9 text-2xl drop-shadow sm:text-3xl">🎈</span>
+        {/* sparkles */}
+        <Sparkles className="absolute left-[14%] top-16 size-5 text-white/80" />
+        <Sparkles className="absolute right-[34%] top-6 size-4 text-amber-200/90" />
+      </div>
+
+      {/* "完成！" badge + director screen (right, xl only) */}
+      <div className="pointer-events-none absolute right-6 top-1/2 hidden -translate-y-1/2 flex-col items-center gap-2 xl:flex">
+        <span className="rounded-xl bg-slate-900/85 px-4 py-1.5 font-heading text-lg font-extrabold text-white shadow-lg">
+          完成！
+        </span>
+        <div className="rounded-2xl bg-gradient-to-br from-fuchsia-500/30 to-indigo-500/30 p-1.5 backdrop-blur">
+          <div className="grid h-28 w-44 place-items-center rounded-xl bg-gradient-to-br from-violet-200 to-indigo-200 shadow-inner">
+            <Mascot emoji="🐰" hue={300} className="size-16" />
+            <span className="mt-1 text-[10px] font-bold tracking-widest text-violet-700">DIRECTOR</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ===== Headline ===== */}
+      <h1 className="relative text-center font-heading text-3xl font-extrabold leading-snug text-white drop-shadow-md sm:text-5xl">
+        AIと一緒に、<span className="text-sky-300">ワクワク</span>する
+        <span className="text-amber-300">CM</span>を作ろう！
+      </h1>
+
+      {/* ===== 3 steps ===== */}
+      <div className="relative mx-auto mt-7 flex max-w-3xl flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+        {STEPS.map((s, i) => (
+          <div key={s.n} className="flex flex-1 items-center gap-3">
+            <motion.div
+              whileHover={{ y: -3 }}
+              className="flex w-full flex-col items-center gap-2 rounded-2xl bg-white/95 p-4 text-center card-soft"
+            >
+              <div className="flex items-center gap-2">
+                <span className={`grid size-6 place-items-center rounded-full bg-gradient-to-br ${s.ring} text-xs font-bold text-white`}>
+                  {s.n}
+                </span>
+                <span className="font-heading font-bold">{s.title}</span>
+              </div>
+              <Mascot emoji={s.emoji} hue={s.hue} className="size-16" />
+              <span className="text-xs text-muted-foreground">{s.sub}</span>
+            </motion.div>
+            {i < STEPS.length - 1 && (
+              <ArrowRight className="hidden size-6 shrink-0 text-white drop-shadow sm:block" />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* ===== CTA ===== */}
+      <div className="relative mt-7 flex justify-center">
+        <motion.button
+          onClick={onStart}
+          whileHover={{ scale: 1.03 }}
+          whileTap={{ scale: 0.98 }}
+          className="bg-gradient-cta glow-cta inline-flex items-center gap-2 rounded-full px-8 py-3.5 font-heading text-lg font-extrabold text-white"
+        >
+          <Rocket className="size-5" /> 今すぐCMを作る！ <Sparkles className="size-4" />
+        </motion.button>
+      </div>
+
+      {/* ===== Engine bar ===== */}
+      <div className="relative mt-6">
+        <EnginePills />
+      </div>
+    </section>
+  );
+}

--- a/src/components/dashboard/mascot.tsx
+++ b/src/components/dashboard/mascot.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Lightweight CSS/SVG mascot placeholder — stands in for the 3D character art.
+ * Swap `src` later to drop in a real PNG/SVG without touching layout.
+ */
+export function Mascot({
+  className,
+  src,
+  hue = 255,
+  emoji = "🤖",
+}: {
+  className?: string;
+  src?: string;
+  hue?: number;
+  emoji?: string;
+}) {
+  if (src) {
+    // eslint-disable-next-line @next/next/no-img-element
+    return <img src={src} alt="" aria-hidden className={cn("object-contain", className)} />;
+  }
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "flex items-center justify-center rounded-2xl text-2xl shadow-inner",
+        className,
+      )}
+      style={{
+        background: `radial-gradient(120% 120% at 30% 20%, oklch(0.85 0.12 ${hue} / 0.9), oklch(0.6 0.18 ${hue} / 0.85))`,
+      }}
+    >
+      <span className="drop-shadow-sm">{emoji}</span>
+    </div>
+  );
+}

--- a/src/components/dashboard/recent-projects.tsx
+++ b/src/components/dashboard/recent-projects.tsx
@@ -1,0 +1,40 @@
+import { MoreVertical, Loader2 } from "lucide-react";
+
+const PROJECTS = [
+  { name: "美容液 CM", at: "2025/05/25 14:30", status: "done", emoji: "💧" },
+  { name: "コーヒーショップ", at: "2025/05/25 11:20", status: "done", emoji: "☕" },
+  { name: "新商品プロモーション", at: "2025/05/24 18:45", status: "running", emoji: "🚀" },
+  { name: "ECサイト広告", at: "2025/05/24 09:15", status: "done", emoji: "🛍️" },
+];
+
+export function RecentProjects() {
+  return (
+    <div className="rounded-2xl border border-border bg-card p-4 card-soft">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="font-heading text-base font-bold">最近のプロジェクト</h2>
+        <button className="text-xs font-semibold text-brand-purple hover:underline">すべて見る →</button>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {PROJECTS.map((p) => (
+          <li key={p.name} className="flex items-center gap-3 rounded-xl bg-muted/50 p-2.5">
+            <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-card text-lg card-soft">{p.emoji}</span>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold">{p.name}</p>
+              <p className="text-xs text-muted-foreground tabular-nums">{p.at}</p>
+            </div>
+            {p.status === "done" ? (
+              <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-bold text-emerald-700">完了</span>
+            ) : (
+              <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2.5 py-1 text-xs font-bold text-blue-700">
+                <Loader2 className="size-3 animate-spin" /> 生成中…
+              </span>
+            )}
+            <button className="text-muted-foreground hover:text-foreground" aria-label="メニュー">
+              <MoreVertical className="size-4" />
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/dashboard/sidebar.tsx
+++ b/src/components/dashboard/sidebar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import {
+  Clapperboard,
+  FolderKanban,
+  LayoutDashboard,
+  History,
+  Film,
+  Palette,
+  Settings,
+  KeyRound,
+  Crown,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Mascot } from "./mascot";
+
+const NAV = [
+  { icon: LayoutDashboard, label: "ダッシュボード", active: true },
+  { icon: FolderKanban, label: "プロジェクト" },
+  { icon: Film, label: "テンプレート" },
+  { icon: History, label: "生成履歴" },
+  { icon: Clapperboard, label: "動画ライブラリ" },
+  { icon: Palette, label: "ブランドキット" },
+  { icon: Settings, label: "設定" },
+  { icon: KeyRound, label: "APIキー" },
+];
+
+export function Sidebar() {
+  return (
+    <aside className="bg-sidebar-grad sticky top-0 hidden h-dvh w-64 shrink-0 flex-col gap-6 px-4 py-5 text-sidebar-foreground lg:flex">
+      {/* Logo */}
+      <div className="flex items-center gap-2 px-2">
+        <span className="bg-gradient-primary flex size-9 items-center justify-center rounded-xl">
+          <Clapperboard className="size-5 text-white" />
+        </span>
+        <span className="font-heading text-xl font-extrabold">auto-cm</span>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex flex-col gap-1">
+        {NAV.map((item) => (
+          <button
+            key={item.label}
+            className={cn(
+              "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors",
+              item.active
+                ? "bg-gradient-primary text-white shadow-lg"
+                : "text-sidebar-muted hover:bg-white/5 hover:text-sidebar-foreground",
+            )}
+          >
+            <item.icon className="size-4.5" />
+            {item.label}
+          </button>
+        ))}
+      </nav>
+
+      {/* PRO plan credit widget */}
+      <div className="mt-auto rounded-2xl border border-white/10 bg-white/5 p-4">
+        <div className="mb-2 flex items-center gap-1.5 text-xs font-bold text-amber-300">
+          <Crown className="size-3.5" /> PRO PLAN
+        </div>
+        <p className="text-xs text-sidebar-muted">生成クレジット</p>
+        <p className="font-heading text-2xl font-extrabold tabular-nums">
+          850 <span className="text-sm font-medium text-sidebar-muted">/ 1,000</span>
+        </p>
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
+          <div className="bg-gradient-primary h-full w-[85%] rounded-full" />
+        </div>
+        <button className="bg-gradient-primary mt-3 w-full rounded-xl py-2 text-xs font-bold text-white">
+          プランをアップグレード
+        </button>
+      </div>
+
+      <Mascot emoji="🤖" hue={255} className="mx-auto size-20" />
+    </aside>
+  );
+}

--- a/src/components/dashboard/stat-cards.tsx
+++ b/src/components/dashboard/stat-cards.tsx
@@ -1,0 +1,39 @@
+import { Sparkles, TrendingUp, Zap, Users, CheckCircle2 } from "lucide-react";
+import { Mascot } from "./mascot";
+
+const STATS = [
+  { icon: CheckCircle2, label: "総生成数", value: "128", delta: "↑ 22%", sub: "今月", grad: "from-violet-400 to-purple-500" },
+  { icon: Sparkles, label: "完了率", value: "98.5%", delta: "↑ 5%", sub: "今月", grad: "from-amber-400 to-orange-500" },
+  { icon: Zap, label: "平均生成時間", value: "62秒", delta: "↓ 15%", sub: "今月", grad: "from-blue-400 to-indigo-500" },
+  { icon: Users, label: "使用クレジット", value: "850", delta: "/ 1,000", sub: "今月", grad: "from-pink-400 to-rose-500" },
+];
+
+export function StatCards() {
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:grid-cols-5">
+      {STATS.map((s) => (
+        <div key={s.label} className="rounded-2xl border border-border bg-card p-4 card-soft">
+          <span className={`mb-2 grid size-9 place-items-center rounded-xl bg-gradient-to-br ${s.grad} text-white`}>
+            <s.icon className="size-4.5" />
+          </span>
+          <p className="text-xs text-muted-foreground">{s.label}</p>
+          <p className="font-heading text-2xl font-extrabold tabular-nums">
+            {s.value} <span className="text-xs font-bold text-emerald-600">{s.delta}</span>
+          </p>
+          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+            <TrendingUp className="size-3" /> {s.sub}
+          </p>
+        </div>
+      ))}
+
+      <div className="bg-gradient-primary col-span-2 flex items-center justify-between gap-2 rounded-2xl p-4 text-white lg:col-span-1">
+        <p className="font-heading text-sm font-bold leading-snug">
+          すごいCMが
+          <br />
+          できたよ〜！
+        </p>
+        <Mascot emoji="🥳" hue={320} className="size-14 shrink-0" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/studio-launcher.tsx
+++ b/src/components/dashboard/studio-launcher.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Hero } from "./hero";
+import { Studio } from "@/components/studio/studio";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import type { EngineId } from "@/lib/engines/types";
+
+export function StudioLauncher({
+  liveEngines,
+  demo,
+}: {
+  liveEngines: EngineId[];
+  demo: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Hero onStart={() => setOpen(true)} />
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[92vh] overflow-y-auto sm:max-w-5xl">
+          <DialogHeader>
+            <DialogTitle className="font-heading text-2xl font-extrabold">
+              <span className="text-gradient-primary">CMを作る</span> 🎬
+            </DialogTitle>
+            <DialogDescription>
+              商品画像をアップロード → AIが解析・台本生成 → エンジンを選んで生成。
+              {demo && "（現在デモモード：サンプル動画で全フローを体験できます）"}
+            </DialogDescription>
+          </DialogHeader>
+          <Studio liveEngines={liveEngines} />
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/components/dashboard/topbar.tsx
+++ b/src/components/dashboard/topbar.tsx
@@ -1,0 +1,30 @@
+import { Bell, HelpCircle, Megaphone, ChevronDown } from "lucide-react";
+
+export function Topbar() {
+  return (
+    <header className="sticky top-0 z-30 flex items-center justify-between gap-4 border-b border-border/70 bg-background/80 px-4 py-3 backdrop-blur sm:px-6">
+      {/* Center info pill */}
+      <div className="hidden flex-1 justify-center md:flex">
+        <div className="inline-flex items-center gap-2 rounded-full border border-border bg-card px-4 py-1.5 text-sm font-medium text-muted-foreground card-soft">
+          <Megaphone className="size-4 text-brand-purple" />
+          商品URLを入れるだけ！ AIが5つのエンジンで同時にCMを生成します
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 sm:gap-3 md:ml-auto">
+        <button className="relative grid size-9 place-items-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:text-foreground" aria-label="通知">
+          <Bell className="size-4.5" />
+          <span className="bg-gradient-cta absolute -right-0.5 -top-0.5 grid size-4 place-items-center rounded-full text-[10px] font-bold text-white">3</span>
+        </button>
+        <button className="grid size-9 place-items-center rounded-full border border-border bg-card text-muted-foreground transition-colors hover:text-foreground" aria-label="ヘルプ">
+          <HelpCircle className="size-4.5" />
+        </button>
+        <button className="flex items-center gap-2 rounded-full border border-border bg-card py-1 pl-1 pr-2.5 card-soft">
+          <span className="bg-gradient-primary grid size-7 place-items-center rounded-full text-xs font-bold text-white">CC</span>
+          <span className="hidden text-sm font-semibold sm:block">Customer Cloud</span>
+          <ChevronDown className="size-4 text-muted-foreground" />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/studio/dropzone.tsx
+++ b/src/components/studio/dropzone.tsx
@@ -58,10 +58,10 @@ export function Dropzone({ previewUrl, onFile, onClear }: Props) {
       }}
       className={cn(
         "flex aspect-square w-full flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-6 text-center transition-colors",
-        dragging ? "border-brand bg-brand/10" : "border-border hover:border-brand/60 hover:bg-muted/40",
+        dragging ? "border-primary bg-primary/10" : "border-border hover:border-primary/60 hover:bg-muted/40",
       )}
     >
-      <span className="flex size-14 items-center justify-center rounded-full bg-brand/15 text-brand">
+      <span className="flex size-14 items-center justify-center rounded-full bg-primary/15 text-primary">
         <ImagePlus className="size-7" />
       </span>
       <span className="font-medium">商品画像をアップロード</span>

--- a/src/components/studio/engine-card.tsx
+++ b/src/components/studio/engine-card.tsx
@@ -26,8 +26,8 @@ export function EngineCard({ info, selected, recommended, live, onToggle }: Prop
       className={cn(
         "relative flex w-full flex-col gap-3 rounded-xl border p-4 text-left transition-colors",
         selected
-          ? "border-brand bg-brand/10 ring-1 ring-brand"
-          : "border-border bg-card hover:border-brand/50",
+          ? "border-primary bg-primary/10 ring-1 ring-primary"
+          : "border-border bg-card hover:border-primary/50",
       )}
     >
       <div className="flex items-start justify-between gap-2">
@@ -35,7 +35,7 @@ export function EngineCard({ info, selected, recommended, live, onToggle }: Prop
           <div className="flex items-center gap-2">
             <h3 className="truncate font-heading text-base font-semibold">{info.name}</h3>
             {recommended && (
-              <Badge className="bg-brand text-brand-foreground hover:bg-brand">
+              <Badge className="bg-primary text-primary-foreground hover:bg-primary">
                 <Sparkles className="mr-1 size-3" /> 推奨
               </Badge>
             )}
@@ -45,7 +45,7 @@ export function EngineCard({ info, selected, recommended, live, onToggle }: Prop
         <span
           className={cn(
             "flex size-5 shrink-0 items-center justify-center rounded-full border",
-            selected ? "border-brand bg-brand text-brand-foreground" : "border-muted-foreground/40",
+            selected ? "border-primary bg-primary text-primary-foreground" : "border-muted-foreground/40",
           )}
         >
           {selected && <Check className="size-3.5" />}
@@ -59,7 +59,7 @@ export function EngineCard({ info, selected, recommended, live, onToggle }: Prop
           {Array.from({ length: 5 }).map((_, i) => (
             <Star
               key={i}
-              className={cn("size-3", i < info.quality ? "fill-brand text-brand" : "text-muted-foreground/30")}
+              className={cn("size-3", i < info.quality ? "fill-primary text-primary" : "text-muted-foreground/30")}
             />
           ))}
         </span>

--- a/src/components/studio/studio.tsx
+++ b/src/components/studio/studio.tsx
@@ -330,7 +330,7 @@ function ResultCard({ run, aspect }: { run: EngineRun; aspect: AspectRatio }) {
       >
         {pending && (
           <div className="flex flex-col items-center gap-2 text-muted-foreground">
-            <Loader2 className="size-6 animate-spin text-brand" />
+            <Loader2 className="size-6 animate-spin text-primary" />
             <span className="text-xs">生成中… ({info.estimatedTime})</span>
           </div>
         )}
@@ -359,7 +359,7 @@ function ResultCard({ run, aspect }: { run: EngineRun; aspect: AspectRatio }) {
 function StatusBadge({ status }: { status: EngineRun["status"] }) {
   const map = {
     pending: { label: "待機", cls: "bg-muted text-muted-foreground" },
-    processing: { label: "生成中", cls: "bg-brand/15 text-brand" },
+    processing: { label: "生成中", cls: "bg-primary/15 text-primary" },
     succeeded: { label: "完成", cls: "bg-green-500/15 text-green-500" },
     failed: { label: "失敗", cls: "bg-destructive/15 text-destructive" },
   }[status];
@@ -380,7 +380,7 @@ function StepBar({ step }: { step: Step }) {
           <span
             className={cn(
               "flex size-7 items-center justify-center rounded-full text-xs font-semibold transition-colors tabular-nums",
-              i <= idx ? "bg-brand text-brand-foreground" : "bg-muted text-muted-foreground",
+              i <= idx ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground",
             )}
           >
             {i + 1}
@@ -438,8 +438,8 @@ function ChoiceGroup<T extends string | number>({
             className={cn(
               "rounded-md border px-2 py-1.5 text-xs transition-colors",
               value === o.v
-                ? "border-brand bg-brand/10 text-foreground"
-                : "border-border text-muted-foreground hover:border-brand/50",
+                ? "border-primary bg-primary/10 text-foreground"
+                : "border-border text-muted-foreground hover:border-primary/50",
             )}
           >
             {o.label}


### PR DESCRIPTION
参考画像（Customer Cloud風カラフルダッシュボード）に合わせて**見た目のみ刷新**。機能・API・libは不変。

- 明るいテーマ + ブルー/パープル/ピンク + オレンジCTA + 丸ゴシック
- ダークサイドバー（ナビ/PROクレジット/マスコット）+ トップバー
- ヒーロー（グラデ空シーン・色付き見出し・3ステップ・完成!スクリーン・エンジンバー）
- サンプルセクション（最近のプロジェクト/生成結果5枚/統計カード）
- Studioは light化しCTAモーダルで起動（ロジック不変）

検証: tsc 0 / build OK / dev でダッシュボード&モーダル目視確認（screenshot）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)