### PR TITLE
fix(veo3): drop unsupported generateAudio param

### DIFF
--- a/scripts/test-veo3.mjs
+++ b/scripts/test-veo3.mjs
@@ -1,0 +1,58 @@
+import { writeFileSync, readFileSync, existsSync } from "node:fs";
+
+let KEY = process.env.GEMINI_API_KEY;
+if (!KEY && existsSync(".env.local")) KEY = readFileSync(".env.local", "utf8").match(/GEMINI_API_KEY=(.+)/)?.[1].trim();
+const BASE = "https://generativelanguage.googleapis.com/v1beta";
+const MODEL = "veo-3.0-fast-generate-001";
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const prompt =
+  "A cinematic 8-second commercial: a glowing premium cosmetic serum bottle on a marble surface, " +
+  "slow dolly-in, warm golden light, water droplets, a calm female voice speaking in Japanese: " +
+  "「うるおう、わたしへ。AURUM ÉCLAT。」";
+
+console.log("submitting Veo3…");
+let res = await fetch(`${BASE}/models/${MODEL}:predictLongRunning?key=${KEY}`, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ instances: [{ prompt }], parameters: { aspectRatio: "16:9" } }),
+});
+if (!res.ok) {
+  console.error("SUBMIT FAILED", res.status, await res.text());
+  process.exit(1);
+}
+const op = await res.json();
+console.log("operation:", op.name);
+
+let done, last;
+for (let i = 0; i < 40; i++) {
+  await sleep(10000);
+  const r = await fetch(`${BASE}/${op.name}?key=${KEY}`);
+  last = await r.json();
+  done = last.done;
+  process.stdout.write(`  poll ${i + 1}: done=${!!done}\n`);
+  if (done) break;
+}
+if (!done) { console.error("TIMEOUT"); process.exit(2); }
+if (last.error) { console.error("OP ERROR", JSON.stringify(last.error)); process.exit(3); }
+
+console.log("response keys:", JSON.stringify(Object.keys(last.response || {})));
+console.log("RESPONSE (trimmed):", JSON.stringify(last.response).slice(0, 600));
+
+// try to locate the video uri across plausible paths
+const r = last.response || {};
+const uri =
+  r?.generateVideoResponse?.generatedSamples?.[0]?.video?.uri ||
+  r?.generatedSamples?.[0]?.video?.uri ||
+  r?.generateVideoResponse?.generatedVideos?.[0]?.video?.uri ||
+  r?.videos?.[0]?.uri;
+console.log("video uri:", uri);
+if (!uri) process.exit(4);
+
+// download (try ?key= then header)
+let dl = await fetch(uri.includes("?") ? `${uri}&key=${KEY}` : `${uri}?key=${KEY}`);
+if (!dl.ok) dl = await fetch(uri, { headers: { "x-goog-api-key": KEY } });
+console.log("download status:", dl.status, dl.headers.get("content-type"));
+const buf = Buffer.from(await dl.arrayBuffer());
+writeFileSync("/tmp/veo3-smoke.mp4", buf);
+console.log("saved /tmp/veo3-smoke.mp4", buf.length, "bytes");

--- a/src/lib/engines/veo3.ts
+++ b/src/lib/engines/veo3.ts
@@ -22,7 +22,8 @@ export const veo3Engine: VideoEngine = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         instances: [instance],
-        parameters: { aspectRatio: params.aspectRatio, generateAudio: true },
+        // Veo 3 generates native audio automatically; `generateAudio` is rejected (400).
+        parameters: { aspectRatio: params.aspectRatio },
       }),
     });
     if (!res.ok) throw new Error(`Veo3 submit failed: ${res.status} ${await res.text()}`);


### PR DESCRIPTION
Veo3実生成をローカル検証→`generateAudio`が400になるバグを修正。8秒1280x720音声付きMP4の生成を確認。🤖 Generated with [Claude Code](https://claude.com/claude-code)